### PR TITLE
Ensure WP GraphQL is Loaded Before Registering Add-on

### DIFF
--- a/eea-recurring-events-bootstrap.php
+++ b/eea-recurring-events-bootstrap.php
@@ -7,7 +7,9 @@
 add_action(
     'AHEE__EE_System__load_espresso_addons',
     static function () {
-        if (class_exists('EE_Addon')
+        if (defined('EE_PLUGIN_DIR_PATH')
+            && is_readable(EE_PLUGIN_DIR_PATH . 'core/third_party_libs/wp-graphql')
+            && class_exists('EE_Addon')
             && class_exists('EventEspresso\core\domain\DomainBase')
         ) {
             try {
@@ -15,7 +17,7 @@ add_action(
                 EE_Dependency_Map::register_dependencies(
                     'EventEspresso\RecurringEvents\domain\Domain',
                     [
-                        'EE_Dependency_Map'                               => EE_Dependency_Map::load_from_cache,
+                        'EE_Dependency_Map'                           => EE_Dependency_Map::load_from_cache,
                         'EventEspresso\RecurringEvents\domain\Domain' => EE_Dependency_Map::load_from_cache,
                     ]
                 );
@@ -41,12 +43,16 @@ add_action(
  */
 function getRemDomain()
 {
-    return EventEspresso\core\domain\DomainFactory::getShared(
-        new EventEspresso\core\domain\values\FullyQualifiedName(
-            'EventEspresso\RecurringEvents\domain\Domain'
-        ),
-        [ EE_REM_PLUGIN_FILE, EE_REM_VERSION]
-    );
+    static $domain;
+    if (! $domain instanceof EventEspresso\RecurringEvents\domain\Domain) {
+        $domain = EventEspresso\core\domain\DomainFactory::getShared(
+            new EventEspresso\core\domain\values\FullyQualifiedName(
+                'EventEspresso\RecurringEvents\domain\Domain'
+            ),
+            [EE_REM_PLUGIN_FILE, EE_REM_VERSION]
+        );
+    }
+    return $domain;
 }
 
 


### PR DESCRIPTION
After switching to EE core master branch to work on something there, I refreshed the WP plugins page while REM was still active which kinda resulted in a WSOD. This is because we haven't yet set the correct min EE core version since EDTR has not been merged into master. So as an additional safeguard, this PR adds a check for the WP GQL plugin that is bundled with core before registering the plugin.