### PR TITLE
Deploy from dev branch

### DIFF
--- a/.github/workflows/deploy-to-barista.yml
+++ b/.github/workflows/deploy-to-barista.yml
@@ -2,7 +2,7 @@ name: Deploy to barista site
 
 on:
   push:
-    branches: [barista]
+    branches: [dev]
 
 jobs:
   deploy-to-barista-site:

--- a/.github/workflows/deploy-to-rc.yml
+++ b/.github/workflows/deploy-to-rc.yml
@@ -3,6 +3,7 @@ name: Deploy to RC site
 on:
   push:
     branches:
+      - dev
       # If the branch name starts with "rc-"
       - rc-**
 jobs:


### PR DESCRIPTION
This PR updates the deployment workflow to deploy from `dev` branch.

See [core/issues/3241](https://github.com/eventespresso/event-espresso-core/issues/3241)