### PR TITLE
Fix `RCR_name` Field Size

### DIFF
--- a/domain/services/data_migration_scripts/EE_DMS_Recurring_Events_1_0_0.dms.php
+++ b/domain/services/data_migration_scripts/EE_DMS_Recurring_Events_1_0_0.dms.php
@@ -44,7 +44,7 @@ class EE_DMS_Recurring_Events_1_0_0 extends EE_Data_Migration_Script_Base
         $this->_table_is_new_in_this_version(
             'esp_recurrence',
             'RCR_ID INT UNSIGNED NOT NULL AUTO_INCREMENT,
-					RCR_name varchar(50) NOT NULL,
+					RCR_name varchar(256) NOT NULL,
 					RCR_rRule text NOT NULL,
 					RCR_exRule text DEFAULT NULL,
 					RCR_rDates text DEFAULT NULL,


### PR DESCRIPTION
When working on https://github.com/eventespresso/barista/issues/902 the recurrence entity failed to save when trying to create recurring dates using the details Tony listed in that issue.

the errors were:

in the console:

```
Uncaught (in promise) TypeError: Cannot read property 'id' of undefined
    at useSubmitForm.ts:81
    at async Promise.all (/wp-admin/index 0)
    at async useSubmitForm.ts:62
    at async Container.tsx:38
    at async ContentFooter.tsx:37
(anonymous) @ useSubmitForm.ts:81
```

in the network tab for the failed request:

```
debugMessage: 
	The recurrence could not be created because of the following error(s): WPDB Error occurred, 
	but no error message was logged by wpdb! The wpdb method called was "insert" and the arguments were:
[
    0 => 'wp_esp_recurrence',
    1 => [
        'RCR_name'          => 'every month on Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday for 6 times',
        'RCR_rRule'         => 'DTSTART:20210701T190000Z\nRRULE:FREQ=MONTHLY;INTERVAL=1;BYSETPOS=-1;BYDAY=MO,TU,WE,TH,FR,SA,SU;COUNT=6;WKST=MO',
        'RCR_rDates'        => '[]',
        'RCR_exDates'       => '[]',
        'RCR_date_duration' => '1:hours',
    ],
    2 => [
        0 => '%s',
        1 => '%s',
        2 => '%s',
        3 => '%s',
        4 => '%s',
    ],
];
```

turns out the `RCR_name` field declaration was set to `varchar(50)` but `every month on Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday for 6 times` is around 90 chars in length.

This PR increase the size of that field to 256