### PR TITLE
🐛 Fix EEM_Recurrence field defaults

### DIFF
--- a/domain/entities/db_models/EEM_Recurrence.model.php
+++ b/domain/entities/db_models/EEM_Recurrence.model.php
@@ -46,19 +46,19 @@ class EEM_Recurrence extends EEM_Base
                     'RCR_exRule',
                     esc_html__('Exclusion Rule', 'event_espresso'),
                     true,
-                    null
+                    ''
                 ),
                 'RCR_rDates'        => new EE_Plain_Text_Field(
                     'RCR_rDates',
                     esc_html__('Recurrence Dates', 'event_espresso'),
                     true,
-                    null
+                    ''
                 ),
                 'RCR_exDates'       => new EE_Plain_Text_Field(
                     'RCR_exDates',
                     esc_html__('Exclusion Dates', 'event_espresso'),
                     true,
-                    null
+                    ''
                 ),
                 'RCR_date_duration' => new EE_Plain_Text_Field(
                     'RCR_date_duration',

--- a/eea-recurring-events-manager.php
+++ b/eea-recurring-events-manager.php
@@ -95,9 +95,9 @@ function eea_recurring_events_activation_error($error_message = '')
             deactivate_plugins(plugin_basename(__FILE__));
             ?>
 <div class="error">
-	<p><?php echo $error_message; ?></p>
+    <p><?php echo $error_message; ?></p>
 </div>
-<?php
+            <?php
         }
     );
 }


### PR DESCRIPTION
This PR fixes the default values for DB model fields which caused errors by returning `null` when setting PHP return type to `string`.

Fixes #58 