### PR TITLE
Add Cap Check for Rem Admin Route

### DIFF
--- a/domain/Domain.php
+++ b/domain/Domain.php
@@ -18,4 +18,9 @@ class Domain extends DomainBase
      * EE Core Version Required for Add-on
      */
     const CORE_VERSION_REQUIRED = EE_REM_CORE_VERSION_REQUIRED;
+
+    /**
+     * User Capability Required for Add-on
+     */
+    const USER_CAP_REQUIRED = 'ee_recurring_events_manager';
 }

--- a/domain/RecurringEventsManager.php
+++ b/domain/RecurringEventsManager.php
@@ -8,6 +8,7 @@ use EE_Dependency_Map;
 use EE_Error;
 use EE_Register_Addon;
 use EventEspresso\core\domain\DomainInterface;
+use EventEspresso\core\domain\services\capabilities\CapabilitiesChecker;
 use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\exceptions\InvalidEntityException;
 use EventEspresso\core\exceptions\InvalidInterfaceException;
@@ -151,7 +152,7 @@ class RecurringEventsManager extends EE_Addon
                 'EventEspresso\core\services\request\RequestInterface'    => EE_Dependency_Map::load_from_cache,
             ];
             $routes = [
-                'EventEspresso\RecurringEvents\domain\entities\routing\EspressoEventEditor' => $admin_dependencies,
+                'EventEspresso\RecurringEvents\domain\entities\routing\EspressoEventEditor'  => $admin_dependencies,
                 'EventEspresso\RecurringEvents\domain\entities\routing\EventTemplatesAdmin'  => $admin_dependencies,
                 'EventEspresso\RecurringEvents\domain\entities\routing\FrontendRequests'     => $frontend_dependencies,
                 'EventEspresso\RecurringEvents\domain\entities\routing\GQLRequests'          => $gql_dependencies,

--- a/domain/entities/routing/RemAdminRoute.php
+++ b/domain/entities/routing/RemAdminRoute.php
@@ -5,8 +5,12 @@ namespace EventEspresso\RecurringEvents\domain\entities\routing;
 use EE_Admin_Config;
 use EE_Dependency_Map;
 use EventEspresso\core\domain\entities\routing\handlers\admin\AdminRoute;
+use EventEspresso\core\domain\services\capabilities\CapCheck;
+use EventEspresso\core\domain\services\capabilities\CapCheckInterface;
+use EventEspresso\core\exceptions\InvalidDataTypeException;
 use EventEspresso\core\services\loaders\LoaderInterface;
 use EventEspresso\core\services\request\RequestInterface;
+use EventEspresso\RecurringEvents\domain\Domain;
 use EventEspresso\RecurringEvents\domain\services\dependencies\EventEditorDependencyHandler;
 use EventEspresso\RecurringEvents\domain\services\graphql\RegisterResources;
 
@@ -36,6 +40,16 @@ class RemAdminRoute extends AdminRoute
     ) {
         $this->dependency_handler = $dependency_handler;
         parent::__construct($admin_config, $dependency_map, $loader, $request);
+    }
+
+
+    /**
+     * @return CapCheckInterface
+     * @throws InvalidDataTypeException
+     */
+    public function getCapCheck()
+    {
+        return new CapCheck(Domain::USER_CAP_REQUIRED, 'access REM admin');
     }
 
 


### PR DESCRIPTION
plz see: https://github.com/eventespresso/event-espresso-core/pull/3877

This PR:

- defines a domain scope constant for the REM user capability
- adds a cap check to the REM admin route